### PR TITLE
test: fix bench SIGABRT from stale Bitcoin regtest unspendable address

### DIFF
--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -28,7 +28,7 @@ static const DatabaseFormat DATABASE_FORMATS[] = {
        DatabaseFormat::SQLITE,
 };
 
-const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj";
+const std::string ADDRESS_BCRT1_UNSPENDABLE = "rkpepe1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqh584mz";
 
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, const CKey& key);
 


### PR DESCRIPTION
## Root cause
The macOS native job (and every job running the bench sanity check) aborts in `WalletBalanceClean`:

```
Assertion failed: (IsValidDestination(dest)), function generatetoaddress, file mining.cpp, line 29.
kingpepe -m bench -filter=WalletBalanceClean -sanity-check died with SIGABRT
```

`ADDRESS_BCRT1_UNSPENDABLE` in `src/wallet/test/util.h` was still a **Bitcoin** regtest address (`bcrt1q…3xueyj`). KingPepe's regtest bech32 HRP is `rkpepe`, so `DecodeDestination()` rejects the `bcrt` HRP, `IsValidDestination()` returns false, and `generatetoaddress()` aborts.

## Fix
Re-encode the **identical** segwit v0 witness program (32 zero bytes — the unspendable P2WSH) under the KingPepe regtest HRP. Destination and scriptPubKey (`OP_0 <32×0x00>`) are unchanged; only the address string/checksum differ.

## Verification (local, with the v31.1 `kingpepe-tx` binary)
- `kingpepe-tx -regtest` **rejects** the old `bcrt1…` as "invalid TX output address" (reproduces the abort).
- `kingpepe-tx -regtest` **accepts** the new `rkpepe1…`, producing scriptPubKey `0020` + 32 zero bytes — the same unspendable P2WSH script.

## Scope
Test-only fixture change. **No** consensus rules, chain parameters, wallet formats, network identity, ports, address prefixes, genesis data, or mining rules are modified. No tests disabled or weakened.