### PR TITLE
qt, test: fix WalletTests URI scheme expectation (bitcoin: -> kingpepe:)

### DIFF
--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -329,7 +329,7 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("payment_header")->text(), QString("Payment information"));
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("uri_tag")->text(), QString("URI:"));
             QString uri = receiveRequestDialog->QObject::findChild<QLabel*>("uri_content")->text();
-            QCOMPARE(uri.count("bitcoin:"), 2);
+            QCOMPARE(uri.count("kingpepe:"), 2);
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("address_tag")->text(), QString("Address:"));
             QVERIFY(address.isEmpty());
             address = receiveRequestDialog->QObject::findChild<QLabel*>("address_content")->text();


### PR DESCRIPTION
## Root cause
`test_bitcoin-qt` → `WalletTests::walletTests()` fails on every platform that runs the GUI wallet tests:
- **32-bit ARM**: `FAIL! Actual (uri.count("bitcoin:")): 0, Expected: 2` at `qt/test/wallettests.cpp:332`
- **Windows native, VS**: same test aborts (buffered output lost, so the console shows an empty crash)
- (macOS "passes" only because its `test_bitcoin-qt` runs in 0.34s without exercising these GUI wallet tests.)

`GUIUtil::formatBitcoinURI()` emits KingPepe's BIP21 scheme `kingpepe:%1`, and `ReceiveRequestDialog` renders that URI **twice** (link `href` + visible text, receiverequestdialog.cpp:60), so the count of the scheme is 2. The test still asserted the stale `bitcoin:` string.

## Fix
`qt/test/wallettests.cpp:332`: `uri.count("bitcoin:")` → `uri.count("kingpepe:")`. The sibling assertions (amount/label/message, also expecting 2) are scheme-independent and already pass. Resolves both the 32-bit ARM and Windows native VS failures.

## Scope
Test-only fixture change matching the established KingPepe URI scheme. **No** production code, consensus, chain params, wallet format, or network identity changed. No tests disabled.

## Note (out of scope, not changed here)
`GUIUtil::parseBitcoinURI()` (guiutil.cpp:151) still checks `uri.scheme() != "bitcoin"`, inconsistent with `formatBitcoinURI` emitting `kingpepe:`. It is currently self-consistent with `uritests.cpp` (which feeds `bitcoin:` URIs) and is not part of this failure. Flagging for a separate decision since the URI scheme is network identity.