### PR TITLE
test: fix feature_pruning BIP158 false-positive spk for KingPepe genesis

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -494,7 +494,12 @@ class PruneTest(BitcoinTestFramework):
     def test_scanblocks_pruned(self):
         node = self.nodes[5]
         genesis_blockhash = node.getblockhash(0)
-        false_positive_spk = bytes.fromhex("001400000000000000000000000000000000000cadcb")
+        # This scriptPubKey is a BIP158 false positive against KingPepe's genesis
+        # block filter (whose only element is the genesis coinbase output script).
+        # It was found by matching the Golomb-coded set hash of that element for
+        # KingPepe's regtest genesis (hash 352a1a62...a175a8b9); the upstream
+        # value was crafted for Bitcoin's genesis and no longer collides.
+        false_positive_spk = bytes.fromhex("0014000000000000000000000000000000000001535a")
 
         assert genesis_blockhash in node.scanblocks(
             "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0)['relevant_blocks']


### PR DESCRIPTION
## Root cause
`feature_pruning.py::test_scanblocks_pruned` asserts that a crafted scriptPubKey is a **BIP158 false positive** against the genesis block filter, so `scanblocks()` returns genesis as a relevant block:
```
assert genesis_blockhash in node.scanblocks('start', [{'desc': f'raw({false_positive_spk.hex()})'}], 0, 0)['relevant_blocks']
```
The hardcoded value `001400…0cadcb` was crafted for **Bitcoin's** genesis. KingPepe's genesis has a different block hash and coinbase output script, so it no longer collides → assertion fails.

## Fix
Recomputed the false positive for KingPepe's regtest genesis → `0014…01535a`.
The genesis basic filter has one element (the genesis coinbase output script). Its GCS-mapped value — SipHash-2-4 keyed by the genesis hash, mapped into `[0, N·M)` with `N=1, M=784931` — is **371553**; the new spk maps to the same value.

## Validation (offline, no node needed)
My BIP158 implementation was verified by reproducing the **original** upstream value: `001400…0cadcb` maps to the same GCS value (292204) as Bitcoin's regtest genesis coinbase script. Since the implementation exactly matches the known-good case, the KingPepe recomputation is trustworthy.

Test-only fixture; no consensus/network/serialization change.