### PR TITLE
build: fix qt test set_property to match renamed ctest label (test_kingpepe-qt)

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_test(NAME test_kingpepe-qt
 )
 if(WIN32 AND VCPKG_TARGET_TRIPLET)
   set(plugin_path "$<SHELL_PATH:$<PATH:GET_PARENT_PATH,$<PATH:GET_PARENT_PATH,$<TARGET_PROPERTY:Qt6::QWindowsIntegrationPlugin,LOCATION_$<CONFIG>>>>>")
-  set_property(TEST test_bitcoin-qt APPEND PROPERTY
+  set_property(TEST test_kingpepe-qt APPEND PROPERTY
     ENVIRONMENT_MODIFICATION
       # On Windows, vcpkg configures Qt with `-opengl dynamic`, which makes
       # the "minimal" platform plugin unusable due to internal Qt bugs.


### PR DESCRIPTION
Fixes a configure regression from the debrand: the GUI ctest label was renamed `test_bitcoin-qt` -> `test_kingpepe-qt` (`add_test NAME`), but the Windows-only `set_property(TEST test_bitcoin-qt ...)` still referenced the old name, so `cmake --preset vs2026` failed on **Windows native VS**:

```
CMake Error at src/qt/test/CMakeLists.txt:44 (set_property):
  ... given TEST name "test_bitcoin-qt" which does not exist.
```

The block is guarded by `if(WIN32 AND VCPKG_TARGET_TRIPLET)`, so only Windows VS configure was affected (Linux/macOS unaffected). One-line fix pointing `set_property` at the renamed test. No behaviour change; the test binary target remains `test_bitcoin-qt`. No consensus/network changes.